### PR TITLE
Fix card overflow when using browser to zoom in

### DIFF
--- a/css/microprofile-config/mpconfig.css
+++ b/css/microprofile-config/mpconfig.css
@@ -129,16 +129,22 @@
    padding: 5px 10px;
    border: .5px solid black;
    transition: .25s all;
+   display: flex;
+   flex-flow: column;
+   justify-content: center;
+   overflow: hidden;
 }
 
 .ordinalCard:hover, .ordinalCard:focus {
     z-index: 6;
     font-size: 10px;
-    height: 40px;
+    height: auto;
     width: 33%;
     border: 2px solid #E3700D;
     cursor: pointer;
     outline: none;
+    overflow: visible;
+    min-height: 40px;
 }
 
 .ordinal-0 {


### PR DESCRIPTION
With browser zooming in to 50% or less, the text in the ordinal card is overflow. The fix is to hide the overflow in the card and show the full content when the card is hovered over.